### PR TITLE
Fix `navigateBy*` functions

### DIFF
--- a/src/Core.bs.js
+++ b/src/Core.bs.js
@@ -3,17 +3,17 @@
 var Caml_option = require("rescript/lib/js/caml_option.js");
 
 function NavigationHelpersCommon(M) {
-  var navigateByKey = function (key, params, param) {
+  var navigateByKey = function (key, params, navigation) {
     var tmp = {
       key: key
     };
     if (params !== undefined) {
       tmp.params = Caml_option.valFromOption(params);
     }
-    tmp.navigate();
+    navigation.navigate(tmp);
     
   };
-  var navigateByName = function (name, key, params, param) {
+  var navigateByName = function (name, key, params, navigation) {
     var tmp = {
       name: name
     };
@@ -23,7 +23,7 @@ function NavigationHelpersCommon(M) {
     if (params !== undefined) {
       tmp.params = Caml_option.valFromOption(params);
     }
-    tmp.navigate();
+    navigation.navigate(tmp);
     
   };
   return {
@@ -37,17 +37,17 @@ function EventConsumer(M) {
 }
 
 function NavigationScreenProp(M) {
-  var navigateByKey = function (key, params, param) {
+  var navigateByKey = function (key, params, navigation) {
     var tmp = {
       key: key
     };
     if (params !== undefined) {
       tmp.params = Caml_option.valFromOption(params);
     }
-    tmp.navigate();
+    navigation.navigate(tmp);
     
   };
-  var navigateByName = function (name, key, params, param) {
+  var navigateByName = function (name, key, params, navigation) {
     var tmp = {
       name: name
     };
@@ -57,7 +57,7 @@ function NavigationScreenProp(M) {
     if (params !== undefined) {
       tmp.params = Caml_option.valFromOption(params);
     }
-    tmp.navigate();
+    navigation.navigate(tmp);
     
   };
   return {

--- a/src/Core.res
+++ b/src/Core.res
@@ -39,13 +39,17 @@ module NavigationHelpersCommon = (
     unit,
   ) => navigationParams = ""
 
-  @send external navigateBy: navigationParams => unit = "navigate"
+  @send external navigateBy: (navigation, navigationParams) => unit = "navigate"
 
-  let navigateByKey = (~key: string, ~params: option<M.params>=?, _) =>
-    navigateBy(navigateByKeyParams(~key, ~params?, ()))
+  let navigateByKey = (~key: string, ~params: option<M.params>=?, navigation) =>
+    navigateBy(navigation, navigateByKeyParams(~key, ~params?, ()))
 
-  let navigateByName = (~name: string, ~key: option<string>=?, ~params: option<M.params>=?, _) =>
-    navigateBy(navigateByNameParams(~name, ~key?, ~params?, ()))
+  let navigateByName = (
+    ~name: string,
+    ~key: option<string>=?,
+    ~params: option<M.params>=?,
+    navigation,
+  ) => navigateBy(navigation, navigateByNameParams(~name, ~key?, ~params?, ()))
 
   @send external replace: (navigation, string) => unit = "replace"
   @send


### PR DESCRIPTION
The underlying `navigateBy` function didn't accept `navigation`, so it wasn't working. I wired up the `navigation` param in `navigateByKey` and `navigateByName`.
