### PR TITLE
Upgrade to React Navigation 6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "rescript-react-navigation",
   "description": "ReScript bindings for react-navigation.",
-  "version": "5.2.0",
+  "version": "6.0.0",
   "peerDependencies": {
-    "@react-navigation/bottom-tabs": "^5.0.0",
-    "@react-navigation/drawer": "^5.0.0",
-    "@react-navigation/material-bottom-tabs": "^5.0.0",
-    "@react-navigation/material-top-tabs": "^5.0.0",
-    "@react-navigation/native": "^5.0.0",
-    "@react-navigation/stack": "^5.0.0",
+    "@react-navigation/bottom-tabs": "^6.0.0",
+    "@react-navigation/drawer": "^6.0.0",
+    "@react-navigation/material-bottom-tabs": "^6.0.0",
+    "@react-navigation/material-top-tabs": "^6.0.0",
+    "@react-navigation/native": "^6.0.0",
+    "@react-navigation/stack": "^6.0.0",
     "@rescript/react": "^0.10.0",
     "rescript-react-native": "^0.64.3"
   },

--- a/src/BottomTabs.bs.js
+++ b/src/BottomTabs.bs.js
@@ -22,12 +22,17 @@ function Make(M) {
   var $$Navigator = {
     make: make$2
   };
+  var make$3 = bottomTabs.Group;
+  var Group = {
+    make: make$3
+  };
   return {
           Navigation: Navigation,
           bottomTabs: bottomTabs,
           $$Screen: $$Screen,
           ScreenWithCallback: ScreenWithCallback,
-          $$Navigator: $$Navigator
+          $$Navigator: $$Navigator,
+          Group: Group
         };
 }
 

--- a/src/BottomTabs.res
+++ b/src/BottomTabs.res
@@ -57,23 +57,6 @@ module Make = (
     "inactiveTintColor": option<string>,
   }
 
-  @obj
-  external bottomTabBarOptions: (
-    ~keyboardHidesTabBar: bool=?,
-    ~activeTintColor: string=?,
-    ~inactiveTintColor: string=?,
-    ~activeBackgroundColor: string=?,
-    ~inactiveBackgroundColor: string=?,
-    ~allowFontScaling: bool=?,
-    ~showLabel: bool=?,
-    ~labelStyle: ReactNative.Style.t=?,
-    ~tabStyle: ReactNative.Style.t=?,
-    ~labelPosition: labelPositionArgs => string=?,
-    ~adaptive: bool=?,
-    ~style: ReactNative.Style.t=?,
-    unit,
-  ) => bottomTabBarOptions = ""
-
   type accessibilityRole = string
   type accessibilityStates = array<string>
   type routeArgs = {route: route}
@@ -113,14 +96,26 @@ module Make = (
   @obj
   external options: (
     ~title: string=?,
-    ~tabBarLabel: //TODO: dynamic, missing static option: React.ReactNode
-    tabBarLabelArgs => React.element=?,
+    ~unmountOnBlur: bool=?,
+    ~_lazy: bool=?,
+    ~showIcon: bool=?,
+    ~tabBarLabel: tabBarLabelArgs => React.element=?, //TODO: dynamic, missing static option: React.ReactNode
     ~tabBarIcon: tabBarIconArgs => React.element=?,
     ~tabBarAccessibilityLabel: string=?,
     ~tabBarTestID: string=?,
-    ~tabBarVisible: bool=?,
     ~tabBarButton: React.element=?,
-    ~unmountOnBlur: bool=?,
+    ~tabBarHideOnKeyboard: bool=?,
+    ~tabBarActiveTintColor: string=?,
+    ~tabBarInactiveTintColor: string=?,
+    ~tabBarActiveBackgroundColor: string=?,
+    ~tabBarInactiveBackgroundColor: string=?,
+    ~tabBarAllowFontScaling: bool=?,
+    ~tabBarShowLabel: bool=?,
+    ~tabBarLabelPosition: labelPositionArgs => string=?,
+    ~tabBarLabelStyle: ReactNative.Style.t=?,
+    ~tabBarItemStyle: ReactNative.Style.t=?,
+    ~tabBarStyle: ReactNative.Style.t=?,
+    ~tabBarBackground: unit => React.element=?,
     unit,
   ) => options = ""
 
@@ -131,13 +126,13 @@ module Make = (
 
   type optionsCallback = optionsProps => options
 
+  type groupProps = {screenOptions: option<optionsCallback>}
+
   type navigatorProps = {
     initialRouteName: option<string>,
     screenOptions: option<optionsCallback>,
     backBehavior: option<string>,
-    _lazy: option<bool>,
     tabBar: option<bottomTabBarProps => React.element>,
-    tabBarOptions: option<bottomTabBarOptions>,
   }
 
   type renderCallbackProp = {
@@ -157,6 +152,7 @@ module Make = (
   external make: unit => {
     "Navigator": navigatorProps => React.element,
     "Screen": screenProps<M.params> => React.element,
+    "Group": groupProps => React.element,
   } = "createBottomTabNavigator"
 
   let bottomTabs = make()
@@ -193,14 +189,24 @@ module Make = (
       ~initialRouteName: string=?,
       ~screenOptions: optionsCallback=?,
       ~children: React.element,
-      ~backBehavior: [#initialRoute | #order | #history | #none]=?,
+      ~backBehavior: [#firstRoute | #initialRoute | #order | #history | #none]=?,
       ~_lazy: bool=?,
       ~tabBar: bottomTabBarProps => React.element=?,
-      ~tabBarOptions: bottomTabBarOptions=?,
       ~key: string=?,
       unit,
     ) => navigatorProps = ""
 
     let make = bottomTabs["Navigator"]
+  }
+
+  module Group = {
+    @obj
+    external makeProps: (
+      ~screenOptions: optionsCallback=?,
+      ~children: React.element,
+      ~key: string=?,
+      unit,
+    ) => groupProps = ""
+    let make = bottomTabs["Group"]
   }
 }

--- a/src/BottomTabs.res
+++ b/src/BottomTabs.res
@@ -99,6 +99,11 @@ module Make = (
     ~unmountOnBlur: bool=?,
     ~_lazy: bool=?,
     ~showIcon: bool=?,
+    // TODO: Use @react-navigation/elements and add header-related options
+    // https://reactnavigation.org/docs/bottom-tab-navigator/#header-related-options
+    // https://github.com/rescript-react-native/rescript-react-navigation/pull/47
+    // ~header: 'header=?,
+    ~headerShown: bool=?,
     ~tabBarLabel: tabBarLabelArgs => React.element=?, //TODO: dynamic, missing static option: React.ReactNode
     ~tabBarIcon: tabBarIconArgs => React.element=?,
     ~tabBarAccessibilityLabel: string=?,

--- a/src/Core.bs.js
+++ b/src/Core.bs.js
@@ -3,17 +3,20 @@
 var Caml_option = require("rescript/lib/js/caml_option.js");
 
 function NavigationHelpersCommon(M) {
-  var navigateByKey = function (key, params, navigation) {
+  var navigateByKey = function (key, params, merge, navigation) {
     var tmp = {
       key: key
     };
     if (params !== undefined) {
       tmp.params = Caml_option.valFromOption(params);
     }
+    if (merge !== undefined) {
+      tmp.merge = merge;
+    }
     navigation.navigate(tmp);
     
   };
-  var navigateByName = function (name, key, params, navigation) {
+  var navigateByName = function (name, key, params, merge, navigation) {
     var tmp = {
       name: name
     };
@@ -22,6 +25,9 @@ function NavigationHelpersCommon(M) {
     }
     if (params !== undefined) {
       tmp.params = Caml_option.valFromOption(params);
+    }
+    if (merge !== undefined) {
+      tmp.merge = merge;
     }
     navigation.navigate(tmp);
     
@@ -37,17 +43,20 @@ function EventConsumer(M) {
 }
 
 function NavigationScreenProp(M) {
-  var navigateByKey = function (key, params, navigation) {
+  var navigateByKey = function (key, params, merge, navigation) {
     var tmp = {
       key: key
     };
     if (params !== undefined) {
       tmp.params = Caml_option.valFromOption(params);
     }
+    if (merge !== undefined) {
+      tmp.merge = merge;
+    }
     navigation.navigate(tmp);
     
   };
-  var navigateByName = function (name, key, params, navigation) {
+  var navigateByName = function (name, key, params, merge, navigation) {
     var tmp = {
       name: name
     };
@@ -56,6 +65,9 @@ function NavigationScreenProp(M) {
     }
     if (params !== undefined) {
       tmp.params = Caml_option.valFromOption(params);
+    }
+    if (merge !== undefined) {
+      tmp.merge = merge;
     }
     navigation.navigate(tmp);
     

--- a/src/Core.res
+++ b/src/Core.res
@@ -2,7 +2,7 @@ type rec route<'params> = {
   key: string,
   name: string,
   params: option<'params>,
-  state: option<navigationState<'params>>,
+  path: option<string>,
 }
 and navigationState<'params> = {
   key: string,
@@ -29,27 +29,38 @@ module NavigationHelpersCommon = (
   type navigationParams
 
   @obj
-  external navigateByKeyParams: (~key: string, ~params: M.params=?, unit) => navigationParams = ""
+  external navigateByKeyParams: (
+    ~key: string,
+    ~params: M.params=?,
+    ~merge: bool=?,
+    unit,
+  ) => navigationParams = ""
 
   @obj
   external navigateByNameParams: (
     ~name: string,
     ~key: string=?,
     ~params: M.params=?,
+    ~merge: bool=?,
     unit,
   ) => navigationParams = ""
 
   @send external navigateBy: (navigation, navigationParams) => unit = "navigate"
 
-  let navigateByKey = (~key: string, ~params: option<M.params>=?, navigation) =>
-    navigateBy(navigation, navigateByKeyParams(~key, ~params?, ()))
+  let navigateByKey = (
+    ~key: string,
+    ~params: option<M.params>=?,
+    ~merge: option<bool>=?,
+    navigation,
+  ) => navigateBy(navigation, navigateByKeyParams(~key, ~params?, ~merge?, ()))
 
   let navigateByName = (
     ~name: string,
     ~key: option<string>=?,
     ~params: option<M.params>=?,
+    ~merge: option<bool>=?,
     navigation,
-  ) => navigateBy(navigation, navigateByNameParams(~name, ~key?, ~params?, ()))
+  ) => navigateBy(navigation, navigateByNameParams(~name, ~key?, ~params?, ~merge?, ()))
 
   @send external replace: (navigation, string) => unit = "replace"
   @send
@@ -113,9 +124,8 @@ module NavigationScreenProp = (
   external isFirstRouteInParent: (navigation, unit) => bool = "isFirstRouteInParent"
 
   @send
-  external dangerouslyGetParent: navigation => Js.nullable<navigation> = "dangerouslyGetParent"
+  external getParent: navigation => Js.nullable<navigation> = "getParent"
 
   @send
-  external dangerouslyGetState: navigation => Js.nullable<navigationState<'params>> =
-    "dangerouslyGetState"
+  external getState: navigation => Js.nullable<navigationState<'params>> = "getState"
 }

--- a/src/Drawer.bs.js
+++ b/src/Drawer.bs.js
@@ -18,11 +18,16 @@ function Make(M) {
   var $$Navigator = {
     make: make$1
   };
+  var make$2 = stack.Group;
+  var Group = {
+    make: make$2
+  };
   return {
           Navigation: Navigation,
           stack: stack,
           $$Screen: $$Screen,
-          $$Navigator: $$Navigator
+          $$Navigator: $$Navigator,
+          Group: Group
         };
 }
 

--- a/src/Drawer.res
+++ b/src/Drawer.res
@@ -15,8 +15,8 @@ module DrawerNavigationProp = (
   @send external openDrawer: t => unit = "openDrawer"
   @send external closeDrawer: t => unit = "closeDrawer"
   @send external toggleDrawer: t => unit = "toggleDrawer"
+  @send external jumpTo: (t, ~name: string, ~params: 'params=?, unit) => unit = "jumpTo"
 }
-
 module Make = (
   M: {
     type params
@@ -34,6 +34,16 @@ module Make = (
     index: int,
     focused: bool,
     tintColor: option<string>,
+  }
+
+  type drawerLabelProps = {
+    focused: bool,
+    color: string,
+  }
+  type drawerIconProps = {
+    focused: bool,
+    color: string,
+    size: float,
   }
 
   type contentOptions = {
@@ -68,16 +78,45 @@ module Make = (
   @obj
   external options: (
     ~title: string=?,
-    ~drawerLabel: scene => React.element=?,
-    ~drawerIcon: scene => React.element=?,
-    ~drawerLockMode: @string
+    ~_lazy: bool=?,
+    ~drawerLabel: drawerLabelProps => React.element=?,
+    ~drawerIcon: drawerIconProps => React.element=?,
+    ~drawerActiveTintColor: string=?,
+    ~drawerActiveBackgroundColor: string=?,
+    ~drawerInactiveTintColor: string=?,
+    ~drawerInactiveBackgroundColor: string=?,
+    ~drawerItemStyle: ReactNative.Style.t=?,
+    ~drawerLabelStyle: ReactNative.Style.t=?,
+    ~drawerContentContainerStyle: ReactNative.Style.t=?,
+    ~drawerContentStyle: ReactNative.Style.t=?,
+    ~drawerStyle: ReactNative.Style.t=?,
+    ~drawerPosition: [#left | #right]=?,
+    ~drawerType: [#front | #back | #slide | #permanent]=?,
+    ~drawerHideStatusBarOnOpen: bool=?,
+    ~drawerStatusBarAnimation: [#slide | #fade | #none]=?,
+    ~overlayColor: string=?,
+    ~sceneContainerStyle: ReactNative.Style.t=?,
+    ~gestureEnabled: bool=?,
+    ~gestureHandlerProps: 'gestureHandlerProps=?,
+    ~swipeEnabled: bool=?,
+    ~swipeEdgeWidth: float=?,
+    ~swipeMinDistance: float=?,
+    ~keyboardDismissMode: @string
     [
-      | #unlocked
-      | @as("locked-closed") #lockedClosed
-      | @as("locked-open") #lockedOpen
+      | @as("on-drag") #onDrag
+      | #none
     ]=?,
+    ~unmountOnBlur: bool=?,
+    ~headerShown: bool=?,
     unit,
   ) => options = ""
+  // TODO Header options: https://reactnavigation.org/docs/drawer-navigator/#header-related-options
+  // ~drawerLockMode: [@bs.string] [
+  //                    | `unlocked
+  //                    | [@bs.as "locked-closed"] `lockedClosed
+  //                    | [@bs.as "locked-open"] `lockedOpen
+  //                  ]
+  //                    =?,
 
   type optionsProps = {
     navigation: navigation,
@@ -90,10 +129,13 @@ module Make = (
 
   type screenProps
 
+  type groupProps
+
   @module("@react-navigation/drawer")
   external make: unit => {
     "Navigator": navigatorProps => React.element,
     "Screen": screenProps => React.element,
+    "Group": groupProps => React.element,
   } = "createDrawerNavigator"
 
   let stack = make()
@@ -117,40 +159,38 @@ module Make = (
       ~initialRouteName: string=?,
       ~screenOptions: optionsCallback=?,
       ~children: React.element,
-      ~backBehavior: [#initialRoute | #order | #history | #none]=?,
-      ~drawerBackgroundColor: //DrawerNavigationConfig
-      string=?,
-      ~drawerPosition: [#left | #right]=?,
-      ~drawerType: [#front | #back | #slide | #permanent]=?,
-      ~drawerWidth: /*
-         ~drawerWidth: [@bs.unwrap] [
-                         | `Static(float)
-                         | `Dynamic(unit => float)
-                       ]
+      ~backBehavior: [#firstRoute | #initialRoute | #order | #history | #none]=?,
+      ~defaultStatus: @string [@as("open") #open_ | #closed]=?,
+      ~detachInactiveScreens: bool=?,
+      ~useLegacyImplementation: bool=?,
+      /*
+      The content component receives following props by default:
 
+      state - The navigation state of the navigator.
+      navigation - The navigation object for the navigator.
+      descriptors - An descriptor object containing options for the drawer screens. The options can be accessed at descriptors[route.key].options.
+      progress - Reanimated Node that represents the animated position of the drawer (0 is closed; 1 is open).
  */
-      unit => float,
-      ~edgeWidth: float=?,
-      ~hideStatusBar: bool=?,
-      ~keyboardDismissMode: @string
-      [
-        | @as("on-drag") #onDrag
-        | #none
-      ]=?,
-      ~minSwipeDistance: float=?,
-      ~overlayColor: string=?,
-      ~statusBarAnimation: [#slide | #none | #fade]=?,
-      ~_lazy: //TODO: ~gestureHandlerProps: React.ComponentProps<typeof PanGestureHandler>;
-      bool=?,
-      ~unmountInactiveRoutes: bool=?,
       ~drawerContent: React.component<contentComponentProps>=?,
-      ~drawerContentOptions: contentOptions=?,
-      ~sceneContainerStyle: ReactNative.Style.t=?,
-      ~style: ReactNative.Style.t=?,
+      //TODO: ~gestureHandlerProps: React.ComponentProps<typeof PanGestureHandler>;
+      // ~unmountInactiveRoutes: bool=?,
+      // ~drawerContentOptions: Js.t<contentOptions>=?,
+
       ~key: string=?,
       unit,
     ) => navigatorProps = ""
 
     let make = stack["Navigator"]
+  }
+
+  module Group = {
+    @obj
+    external makeProps: (
+      ~screenOptions: optionsCallback=?,
+      ~children: React.element,
+      ~key: string=?,
+      unit,
+    ) => screenProps = ""
+    let make = stack["Group"]
   }
 }

--- a/src/Example.bs.js
+++ b/src/Example.bs.js
@@ -68,6 +68,8 @@ var MainStackScreen_stack = include.stack;
 
 var MainStackScreen_ScreenWithCallback = include.ScreenWithCallback;
 
+var MainStackScreen_Group = include.Group;
+
 var MainStackScreen = {
   StakeParams: StakeParams,
   Navigation: MainStackScreen_Navigation,
@@ -77,6 +79,7 @@ var MainStackScreen = {
   ScreenWithCallback: MainStackScreen_ScreenWithCallback,
   $$Screen: $$Screen,
   $$Navigator: $$Navigator,
+  Group: MainStackScreen_Group,
   make: Example$MainStackScreen
 };
 
@@ -91,8 +94,11 @@ var $$Navigator$1 = include$1.$$Navigator;
 function Example$RootStackScreen(Props) {
   return React.createElement(Native.NavigationContainer, {
               children: React.createElement($$Navigator$1.make, {
-                    mode: "modal",
-                    headerMode: "none",
+                    screenOptions: (function (_optionsProps) {
+                        return {
+                                presentation: "modal"
+                              };
+                      }),
                     children: null
                   }, React.createElement($$Screen$1.make, {
                         name: "Main",
@@ -117,6 +123,8 @@ var RootStackScreen_Header = include$1.Header;
 
 var RootStackScreen_stack = include$1.stack;
 
+var RootStackScreen_Group = include$1.Group;
+
 var RootStackScreen = {
   Navigation: RootStackScreen_Navigation,
   HeaderTitle: RootStackScreen_HeaderTitle,
@@ -125,6 +133,7 @@ var RootStackScreen = {
   ScreenWithCallback: ScreenWithCallback,
   $$Screen: $$Screen$1,
   $$Navigator: $$Navigator$1,
+  Group: RootStackScreen_Group,
   make: Example$RootStackScreen
 };
 

--- a/src/Example.res
+++ b/src/Example.res
@@ -51,7 +51,7 @@ module RootStackScreen = {
   @react.component
   let make = () =>
     <Native.NavigationContainer>
-      <Navigator mode=#modal headerMode=#none>
+      <Navigator screenOptions={_optionsProps => options(~presentation=#modal, ())}>
         <Screen name="Main" component=MainStackScreen.make />
         <ScreenWithCallback name="MyModal">
           {({navigation, route}) => <ModalScreen navigation route />}

--- a/src/MaterialBottomTabs.bs.js
+++ b/src/MaterialBottomTabs.bs.js
@@ -41,13 +41,18 @@ function Make(M) {
   var $$Navigator = {
     make: make$2
   };
+  var make$3 = materialBottomTabs.Group;
+  var Group = {
+    make: make$3
+  };
   return {
           Navigation: Navigation,
           TabBarBadge: TabBarBadge,
           materialBottomTabs: materialBottomTabs,
           $$Screen: $$Screen,
           ScreenWithCallback: ScreenWithCallback,
-          $$Navigator: $$Navigator
+          $$Navigator: $$Navigator,
+          Group: Group
         };
 }
 

--- a/src/MaterialBottomTabs.res
+++ b/src/MaterialBottomTabs.res
@@ -65,6 +65,8 @@ module Make = (
 
   type optionsCallback = optionsProps => options
 
+  type groupProps = {screenOptions: option<optionsCallback>}
+
   type navigatorProps = {
     initialRouteName: option<string>,
     screenOptions: option<optionsCallback>,
@@ -93,6 +95,7 @@ module Make = (
   external make: unit => {
     "Navigator": navigatorProps => React.element,
     "Screen": screenProps<M.params> => React.element,
+    "Group": groupProps => React.element,
   } = "createMaterialBottomTabNavigator"
 
   let materialBottomTabs = make()
@@ -129,7 +132,7 @@ module Make = (
       ~initialRouteName: string=?,
       ~screenOptions: optionsCallback=?,
       ~children: React.element,
-      ~backBehavior: [#initialRoute | #order | #history | #none]=?,
+      ~backBehavior: [#firstRoute | #initialRoute | #order | #history | #none]=?,
       ~shifting: bool=?,
       ~labeled: bool=?,
       ~activeColor: string=?,
@@ -141,5 +144,16 @@ module Make = (
     ) => navigatorProps = ""
 
     let make = materialBottomTabs["Navigator"]
+  }
+
+  module Group = {
+    @obj
+    external makeProps: (
+      ~screenOptions: optionsCallback=?,
+      ~children: React.element,
+      ~key: string=?,
+      unit,
+    ) => groupProps = ""
+    let make = materialBottomTabs["Group"]
   }
 }

--- a/src/MaterialTopTabs.bs.js
+++ b/src/MaterialTopTabs.bs.js
@@ -22,6 +22,10 @@ function Make(M) {
   var $$Navigator = {
     make: make$2
   };
+  var make$3 = materialTopTabs.Group;
+  var Group = {
+    make: make$3
+  };
   var MaterialTopTabBar = {};
   return {
           Navigation: Navigation,
@@ -29,6 +33,7 @@ function Make(M) {
           $$Screen: $$Screen,
           ScreenWithCallback: ScreenWithCallback,
           $$Navigator: $$Navigator,
+          Group: Group,
           MaterialTopTabBar: MaterialTopTabBar
         };
 }

--- a/src/MaterialTopTabs.res
+++ b/src/MaterialTopTabs.res
@@ -110,6 +110,26 @@ module Make = (
     scene => React.element=?,
     ~tabBarAccessibilityLabel: string=?,
     ~tabBarTestID: string=?,
+    ~_lazy: bool=?,
+    ~lazyPlaceholder: React.component<{"route": route}>=?,
+    ~tabBarActiveTintColor: string=?,
+    ~tabBarInactiveTintColor: string=?,
+    ~tabBarPressColor: string=?,
+    ~tabBarPressOpacity: float=?,
+    ~tabBarShowLabel: bool=?,
+    ~tabBarShowIcon: bool=?,
+    ~tabBarAllowFontScaling: bool=?,
+    ~tabBarBounces: bool=?,
+    ~tabBarScrollEnabled: bool=?,
+    ~tabBarIconStyle: ReactNative.Style.t=?,
+    ~tabBarLabelStyle: ReactNative.Style.t=?,
+    ~tabBarItemStyle: ReactNative.Style.t=?,
+    ~tabBarIndicatorStyle: ReactNative.Style.t=?,
+    ~tabBarIndicatorContainerStyle: ReactNative.Style.t=?,
+    ~tabBarContentContainerStyle: ReactNative.Style.t=?,
+    ~tabBarStyle: ReactNative.Style.t=?,
+    // ~renderIndicator: React.component({. "route": route})=?,
+
     unit,
   ) => options = ""
 
@@ -123,11 +143,8 @@ module Make = (
   type navigatorProps = {
     initialRouteName: option<string>,
     screenOptions: option<optionsCallback>,
-    _lazy: option<bool>,
     lazyPreloadDistance: option<int>,
-    lazyPlaceholder: option<React.component<{"route": route}>>,
     tabBar: option<materialTopTabBarProps => React.element>,
-    tabBarOptions: option<materialTopTabBarOptions>,
     tabBarPosition: option<string>,
     backBehavior: option<string>,
     removeClippedSubviews: option<bool>,
@@ -143,6 +160,8 @@ module Make = (
     route: route,
   }
 
+  type groupProps = {screenOptions: option<optionsCallback>}
+
   type screenProps<'params> = {
     name: string,
     options: option<optionsCallback>,
@@ -155,6 +174,7 @@ module Make = (
   external make: unit => {
     "Navigator": navigatorProps => React.element,
     "Screen": screenProps<M.params> => React.element,
+    "Group": groupProps => React.element,
   } = "createMaterialTopTabNavigator"
 
   let materialTopTabs = make()
@@ -191,12 +211,11 @@ module Make = (
       ~initialRouteName: string=?,
       ~screenOptions: optionsCallback=?,
       ~children: React.element,
-      ~backBehavior: [#initialRoute | #order | #history | #none]=?,
+      ~backBehavior: [#firstRoute | #initialRoute | #order | #history | #none]=?,
       ~_lazy: bool=?,
       ~lazyPreloadDistance: int=?,
       ~lazyPlaceholder: React.component<{"route": route}>=?,
       ~tabBar: materialTopTabBarProps => React.element=?,
-      ~tabBarOptions: materialTopTabBarOptions=?,
       ~tabBarPosition: [#top | #bottom]=?,
       ~removeClippedSubviews: bool=?,
       ~keyboardDismissMode: @string
@@ -214,6 +233,17 @@ module Make = (
     ) => navigatorProps = ""
 
     let make = materialTopTabs["Navigator"]
+  }
+
+  module Group = {
+    @obj
+    external makeProps: (
+      ~screenOptions: optionsCallback=?,
+      ~children: React.element,
+      ~key: string=?,
+      unit,
+    ) => groupProps = ""
+    let make = materialTopTabs["Group"]
   }
 
   module MaterialTopTabBar = {

--- a/src/NativeStack.bs.js
+++ b/src/NativeStack.bs.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Core$ReactNavigation = require("./Core.bs.js");
-var NativeStack = require("react-native-screens/native-stack");
+var NativeStack = require("@react-navigation/native-stack");
 
 var NativeStackNavigationScreenProp = Core$ReactNavigation.NavigationScreenProp;
 
@@ -22,15 +22,20 @@ function Make(M) {
   var $$Navigator = {
     make: make$2
   };
+  var make$3 = stack.Group;
+  var Group = {
+    make: make$3
+  };
   return {
           Navigation: Navigation,
           stack: stack,
           ScreenWithCallback: ScreenWithCallback,
           $$Screen: $$Screen,
-          $$Navigator: $$Navigator
+          $$Navigator: $$Navigator,
+          Group: Group
         };
 }
 
 exports.NativeStackNavigationScreenProp = NativeStackNavigationScreenProp;
 exports.Make = Make;
-/* react-native-screens/native-stack Not a pure module */
+/* @react-navigation/native-stack Not a pure module */

--- a/src/NativeStack.res
+++ b/src/NativeStack.res
@@ -63,10 +63,7 @@ module Make = (
     | #systemThickMaterialDark
     | #systemChromeMaterialDark
   ]
-  type headerStyle = {
-    backgroundColor: option<ReactNative.Color.t>,
-    blurEffect: option<blurEffect>,
-  }
+  type headerStyle = {backgroundColor: option<ReactNative.Color.t>}
   type headerTitleStyle = {
     fontFamily: option<string>,
     fontSize: option<float>,
@@ -77,18 +74,19 @@ module Make = (
   @obj
   external options: (
     ~backButtonInCustomView: bool=?,
+    ~animation: [#default | #fade | #flip | #slide_from_right | #slide_from_left | #none]=?,
+    ~animationTypeForReplace: [#push | #pop]=?,
     ~contentStyle: ReactNative.Style.t=?,
-    ~direction: [#rtl | #ltr]=?,
     ~gestureEnabled: bool=?,
     ~headerBackTitle: string=?,
     ~headerBackTitleStyle: headerBackTitleStyle=?,
     ~headerBackTitleVisible: bool=?,
-    ~headerCenter: unit => React.element=?,
-    ~headerHideBackButton: bool=?,
-    ~headerHideShadow: bool=?,
+    ~headerBackVisible: bool=?,
+    ~headerBlurEffect: blurEffect=?,
+    ~headerShadowVisible: bool=?,
     ~headerLargeStyle: headerLargeStyle=?,
     ~headerLargeTitle: bool=?,
-    ~headerLargeTitleHideShadow: bool=?,
+    ~headerLargeTitleShadowVisible: bool=?,
     ~headerLargeTitleStyle: headerLargeTitleStyle=?,
     ~headerLeft: unit => React.element=?,
     ~headerRight: unit => React.element=?,
@@ -97,11 +95,8 @@ module Make = (
     ~headerTintColor: ReactNative.Color.t=?,
     ~headerTitle: string=?,
     ~headerTitleStyle: headerTitleStyle=?,
-    ~headerTopInsetEnabled: bool=?,
-    ~headerTranslucent: bool=?,
-    ~replaceAnimation: [#push | #pop]=?,
-    ~stackAnimation: [#default | #fade | #flip | #slide_from_right | #slide_from_left | #none]=?,
-    ~stackPresentation: [
+    ~headerTransparent: bool=?,
+    ~presentation: [
       | #push
       | #modal
       | #transparentModal
@@ -133,6 +128,8 @@ module Make = (
   }
   type optionsCallback = optionsProps => options
 
+  type groupProps = {screenOptions: option<optionsCallback>}
+
   type navigatorProps = {
     initialRouteName: option<string>,
     screenOptions: option<optionsCallback>,
@@ -149,10 +146,11 @@ module Make = (
     children: option<renderCallbackProp => React.element>,
   }
 
-  @module("react-native-screens/native-stack")
+  @module("@react-navigation/native-stack")
   external make: unit => {
     "Navigator": navigatorProps => React.element,
     "Screen": screenProps<M.params> => React.element,
+    "Group": groupProps => React.element,
   } = "createNativeStackNavigator"
 
   let stack = make()
@@ -194,6 +192,18 @@ module Make = (
     ) => navigatorProps = ""
 
     let make = stack["Navigator"]
+  }
+
+  module Group = {
+    @obj
+    external makeProps: (
+      ~screenOptions: optionsCallback=?,
+      ~children: React.element,
+      ~key: string=?,
+      unit,
+    ) => groupProps = ""
+
+    let make = stack["Group"]
   }
 }
 

--- a/src/Stack.bs.js
+++ b/src/Stack.bs.js
@@ -51,6 +51,10 @@ function Make(M) {
   var $$Navigator = {
     make: make$2
   };
+  var make$3 = stack.Group;
+  var Group = {
+    make: make$3
+  };
   return {
           Navigation: Navigation,
           HeaderTitle: HeaderTitle,
@@ -58,7 +62,8 @@ function Make(M) {
           stack: stack,
           ScreenWithCallback: ScreenWithCallback,
           $$Screen: $$Screen,
-          $$Navigator: $$Navigator
+          $$Navigator: $$Navigator,
+          Group: Group
         };
 }
 

--- a/src/Stack.res
+++ b/src/Stack.res
@@ -139,13 +139,7 @@ module Make = (
     type options = options
   })
 
-  type gestureResponseDistance
-  @obj
-  external gestureResponseDistance: (
-    ~vertical: float=?,
-    ~horizontal: float=?,
-    unit,
-  ) => gestureResponseDistance = ""
+  type gestureResponseDistance = float
 
   module HeaderTitle = {
     type t
@@ -237,6 +231,7 @@ module Make = (
     ~headerBackTitleVisible: bool=?,
     ~headerLeft: stackHeaderLeftButtonProps => React.element=?,
     ~headerLeftContainerStyle: ReactNative.Style.t=?,
+    ~headerMode: [#float | #screen]=?,
     ~headerPressColorAndroid: ReactNative.Color.t=?,
     ~headerRight: headerRightOptions => React.element=?,
     ~headerRightContainerStyle: ReactNative.Style.t=?,
@@ -252,6 +247,8 @@ module Make = (
     ~headerTitleStyle: ReactNative.Style.t=?,
     ~headerTransparent: bool=?,
     ~headerTruncatedBackTitle: string=?,
+    ~keyboardHandlingEnabled: bool=?,
+    ~presentation: [#card | #modal]=?,
     ~safeAreaInsets: safeAreaInsets=?,
     ~title: string=?,
     ~transitionSpec: transitionSpec=?,
@@ -263,12 +260,11 @@ module Make = (
   }
   type optionsCallback = optionsProps => options
 
+  type groupProps = {screenOptions: option<optionsCallback>}
+
   type navigatorProps = {
     initialRouteName: option<string>,
     screenOptions: option<optionsCallback>,
-    mode: option<string>,
-    headerMode: option<string>,
-    keyboardHandlingEnabled: option<bool>,
   }
   type renderCallbackProp = {
     navigation: navigation,
@@ -286,6 +282,7 @@ module Make = (
   external make: unit => {
     "Navigator": navigatorProps => React.element,
     "Screen": screenProps<M.params> => React.element,
+    "Group": groupProps => React.element,
   } = "createStackNavigator"
 
   let stack = make()
@@ -321,15 +318,24 @@ module Make = (
     external makeProps: (
       ~initialRouteName: string=?,
       ~screenOptions: optionsCallback=?,
-      ~mode: [#card | #modal]=?,
-      ~headerMode: [#float | #screen | #none]=?,
-      ~keyboardHandlingEnabled: bool=?,
       ~children: React.element,
       ~key: string=?,
       unit,
     ) => navigatorProps = ""
 
     let make = stack["Navigator"]
+  }
+
+  module Group = {
+    @obj
+    external makeProps: (
+      ~screenOptions: optionsCallback=?,
+      ~children: React.element,
+      ~key: string=?,
+      unit,
+    ) => groupProps = ""
+
+    let make = stack["Group"]
   }
 }
 


### PR DESCRIPTION
I followed https://reactnavigation.org/docs/upgrading-from-5.x, but there might be things that are not covered. However, this is enough for us to use React Navigation 6 in a not-so-small React Native (ReScript + TypeScript) app.

I upgraded package version from 5.2.0 to 6.0.0.

Closes #43 
