### PR TITLE
Improve `Drawer`

### DIFF
--- a/src/Drawer.bs.js
+++ b/src/Drawer.bs.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var Interop = require("./Interop");
 var Core$ReactNavigation = require("./Core.bs.js");
 var Drawer = require("@react-navigation/drawer");
 
@@ -9,22 +10,57 @@ function Make(M) {
   var M$1 = {};
   var include = Core$ReactNavigation.NavigationScreenProp(M$1);
   var Navigation = include;
+  var t = function (prim) {
+    return Interop.identity(prim.VAL);
+  };
+  var string = function (s) {
+    return Interop.identity(s);
+  };
+  var render = function (x) {
+    return Interop.identity(x);
+  };
+  var HeaderTitle = {
+    t: t,
+    string: string,
+    render: render
+  };
+  var t$1 = function (prim) {
+    return Interop.identity(prim.VAL);
+  };
+  var string$1 = function (s) {
+    return Interop.identity(s);
+  };
+  var render$1 = function (x) {
+    return Interop.identity(x);
+  };
+  var DrawerLabel = {
+    t: t$1,
+    string: string$1,
+    render: render$1
+  };
   var stack = Drawer.createDrawerNavigator();
   var make = stack.Screen;
-  var $$Screen = {
+  var ScreenWithCallback = {
     make: make
   };
-  var make$1 = stack.Navigator;
-  var $$Navigator = {
+  var make$1 = stack.Screen;
+  var $$Screen = {
     make: make$1
   };
-  var make$2 = stack.Group;
-  var Group = {
+  var make$2 = stack.Navigator;
+  var $$Navigator = {
     make: make$2
+  };
+  var make$3 = stack.Group;
+  var Group = {
+    make: make$3
   };
   return {
           Navigation: Navigation,
+          HeaderTitle: HeaderTitle,
+          DrawerLabel: DrawerLabel,
           stack: stack,
+          ScreenWithCallback: ScreenWithCallback,
           $$Screen: $$Screen,
           $$Navigator: $$Navigator,
           Group: Group
@@ -33,4 +69,4 @@ function Make(M) {
 
 exports.DrawerNavigationProp = DrawerNavigationProp;
 exports.Make = Make;
-/* @react-navigation/drawer Not a pure module */
+/* ./Interop Not a pure module */


### PR DESCRIPTION
Hi!

I have changed few things:
- add missing options
- enable creating screen with children (`ScreenWithCallback`)
- small improvements in existing options

Type reference:
- [DrawerNavigationOptions](https://github.com/react-navigation/react-navigation/blob/b91c9b05ff96727f5fa6ef0bec51b5d7eac06600/packages/drawer/src/types.tsx#L52)
- [HeaderOptions](https://github.com/react-navigation/react-navigation/blob/82a16690973a7935939a25a66d5786955b6c8ba7/packages/elements/src/types.tsx#L11)

NOTE: The only option I didn't add is `header`, but I left it commented out. I wasn't sure if I could do it properly even though I had a reference in `Stack`.

NOTE: These changes introduce a **breaking change** since I changed the type of `drawerLabel` to be able to accept `string` along the `render fn`.