### PR TITLE
Improve stack and material top tabs

### DIFF
--- a/src/MaterialTopTabs.res
+++ b/src/MaterialTopTabs.res
@@ -112,6 +112,7 @@ module Make = (
     ~tabBarTestID: string=?,
     ~_lazy: bool=?,
     ~lazyPlaceholder: React.component<{"route": route}>=?,
+    ~swipeEnabled: bool=?,
     ~tabBarActiveTintColor: string=?,
     ~tabBarInactiveTintColor: string=?,
     ~tabBarPressColor: string=?,
@@ -224,6 +225,8 @@ module Make = (
         | @as("on-drag") #onDrag
         | #none
       ]=?,
+      // Setting `swipeEnabled` through props is deprecated.
+      // Set it through screen options instead!
       ~swipeEnabled: bool=?,
       ~swipeVelocityImpact: float=?,
       ~sceneContainerStyle: ReactNative.Style.t=?,

--- a/src/Stack.res
+++ b/src/Stack.res
@@ -226,6 +226,7 @@ module Make = (
     ~headerBackAllowFontScaling: bool=?,
     ~headerBackground: headerBackgroundOptions => React.element=?,
     ~headerBackImage: backImage=?,
+    ~headerBackTestID: string=?,
     ~headerBackTitle: string=?,
     ~headerBackTitleStyle: ReactNative.Style.t=?,
     ~headerBackTitleVisible: bool=?,
@@ -260,6 +261,9 @@ module Make = (
   }
   type optionsCallback = optionsProps => options
 
+  type getIdProps = {params: M.params}
+  type getIdCallback = getIdProps => option<string>
+
   type groupProps = {screenOptions: option<optionsCallback>}
 
   type navigatorProps = {
@@ -273,6 +277,7 @@ module Make = (
   type screenProps<'params> = {
     name: string,
     options: option<optionsCallback>,
+    getId: option<getIdCallback>,
     initialParams: option<'params>,
     component: option<React.component<{"navigation": navigation, "route": route}>>,
     children: option<renderCallbackProp => React.element>,
@@ -291,6 +296,7 @@ module Make = (
     external makeProps: (
       ~name: string,
       ~options: optionsCallback=?,
+      ~getId: getIdCallback=?,
       ~initialParams: M.params=?,
       ~children: renderCallbackProp => React.element,
       ~key: string=?,
@@ -304,6 +310,7 @@ module Make = (
     external makeProps: (
       ~name: string,
       ~options: optionsCallback=?,
+      ~getId: getIdCallback=?,
       ~initialParams: M.params=?,
       ~component: React.component<{"navigation": navigation, "route": route}>,
       ~key: string=?,


### PR DESCRIPTION
Hi!

I improved `Stack` binding by adding:
- `headerBackTestID` option
- `getId` screen prop
and improved `MaterialTopTabs` by adding `swipeEnabled` screen option since setting it through props is deprecated.
