### PR TITLE
update: added independent param to NavigationContainer

### DIFF
--- a/src/Native.res
+++ b/src/Native.res
@@ -29,6 +29,7 @@ module NavigationContainer = {
     ~onReady: unit => unit=?,
     ~theme: theme=?,
     ~children: React.element,
+    ~independent: bool=?,
   ) => React.element = "NavigationContainer"
 }
 


### PR DESCRIPTION
Adding binding for prop - `independent` to be able to accommodate nested independent NavigationContainer 
