### PR TITLE
Improve binding of BottomTabs, MaterialBottomTabs

### DIFF
--- a/src/BottomTabs.res
+++ b/src/BottomTabs.res
@@ -18,9 +18,13 @@ module TabBarBadge = {
   external string: string => t = "%identity"
 }
 
+@unboxed
+type rec tabBarLabel = String(string) | Function(tabBarLabelArgs => React.element)
+and tabBarLabelArgs = {focused: bool, color: string}
+
 type rec options = {
   title?: string,
-  tabBarLabel?: string,
+  tabBarLabel?: tabBarLabel,
   tabBarShowLabel?: bool,
   tabBarLabelPosition?: tabBarLabelPosition,
   tabBarLabelStyle?: Style.t,

--- a/src/BottomTabs.res
+++ b/src/BottomTabs.res
@@ -20,7 +20,11 @@ module TabBarBadge = {
 
 @unboxed
 type rec tabBarLabel = String(string) | Function(tabBarLabelArgs => React.element)
-and tabBarLabelArgs = {focused: bool, color: string}
+and tabBarLabelArgs = {
+  focused: bool,
+  color: string,
+  position: tabBarLabelPosition,
+}
 
 type rec options = {
   title?: string,

--- a/src/BottomTabs.res
+++ b/src/BottomTabs.res
@@ -18,13 +18,15 @@ module TabBarBadge = {
   external string: string => t = "%identity"
 }
 
-@unboxed
-type rec tabBarLabel = String(string) | Function(tabBarLabelArgs => React.element)
-and tabBarLabelArgs = {
+type tabBarLabelArgs = {
   focused: bool,
   color: string,
   position: tabBarLabelPosition,
+  children: string,
 }
+
+@unboxed
+type tabBarLabel = String(string) | Function(tabBarLabelArgs => React.element)
 
 type rec options = {
   title?: string,

--- a/src/MaterialBottomTabs.res
+++ b/src/MaterialBottomTabs.res
@@ -16,11 +16,15 @@ module TabBarBadge = {
   external string: string => t = "%identity"
 }
 
+@unboxed
+type rec tabBarLabel = String(string) | Function(tabBarLabelArgs => React.element)
+and tabBarLabelArgs = {focused: bool, color: string}
+
 type options = {
   title?: string,
   tabBarIcon?: tabBarIconOptions => React.element,
   tabBarColor?: Color.t,
-  tabBarLabel?: string,
+  tabBarLabel?: tabBarLabel,
   tabBarBadge?: TabBarBadge.t,
   tabBarAccessibilityLabel?: string,
   tabBarTestID?: string,

--- a/src/MaterialBottomTabs.res
+++ b/src/MaterialBottomTabs.res
@@ -16,9 +16,14 @@ module TabBarBadge = {
   external string: string => t = "%identity"
 }
 
+type tabBarLabelArgs = {
+  focused: bool,
+  color: string,
+  children: string,
+}
+
 @unboxed
-type rec tabBarLabel = String(string) | Function(tabBarLabelArgs => React.element)
-and tabBarLabelArgs = {focused: bool, color: string}
+type tabBarLabel = String(string) | Function(tabBarLabelArgs => React.element)
 
 type options = {
   title?: string,


### PR DESCRIPTION
by making the `tabBarLabel` argument to accept callback.

BottomTabs - https://github.com/react-navigation/react-navigation/blob/b62dccdf467e384362b6dc3399d4d5ac5537c7e1/packages/bottom-tabs/src/types.tsx#L121-L128

MaterialBottomTabs - https://github.com/react-navigation/react-navigation/blob/b62dccdf467e384362b6dc3399d4d5ac5537c7e1/packages/material-top-tabs/src/types.tsx#L96-L102

(This is a breaking change)
